### PR TITLE
2ME support in library broke example code - fixed

### DIFF
--- a/example/qatemswitcher/mainwindow.cpp
+++ b/example/qatemswitcher/mainwindow.cpp
@@ -107,12 +107,12 @@ void MainWindow::onAtemConnected()
 
 void MainWindow::changeProgramInput(int input)
 {
-    m_atemConnection->changeProgramInput(1, input);
+    m_atemConnection->changeProgramInput(0, input);
 }
 
 void MainWindow::changePreviewInput(int input)
 {
-    m_atemConnection->changePreviewInput(1, input);
+    m_atemConnection->changePreviewInput(0, input);
 }
 
 void MainWindow::toogleDsk1Tie()


### PR DESCRIPTION
The introduction of 2ME support in the library broke the qatemswitcher exampel.
I added a simple fix be hardcodeing the exmple to control ME1
