### PR TITLE
Update mainwindow.cpp

### DIFF
--- a/example/qatemswitcher/mainwindow.cpp
+++ b/example/qatemswitcher/mainwindow.cpp
@@ -121,7 +121,7 @@ void MainWindow::onAtemConnected()
 {
     quint8 count = 0;
 
-    foreach(const QAtemConnection::InputInfo &info, m_atemConnection->inputInfos())
+    foreach(const QAtem::InputInfo &info, m_atemConnection->inputInfos())
     {
         if(info.externalType != 0 /*Internal source*/)
         {


### PR DESCRIPTION
I've studied qatemconnection.h and InputInfo is defined under QAtem class rather than QAtemConnection. This small change makes the example compile again on newest version of libqatemcontrol