### PR TITLE
Updated onAMLv level offset

### DIFF
--- a/qatemconnection.cpp
+++ b/qatemconnection.cpp
@@ -1413,7 +1413,7 @@ void QAtemConnection::onAMLv(const QByteArray& payload)
         idlist.append(val.u16);
     }
 
-    int offset = 43 + ((numInputs.u16 - 1) * 2) + 4;
+    int offset = 43 + ((numInputs.u16) * 2);
 
     for(int i = 0; i < numInputs.u16; ++i)
     {


### PR DESCRIPTION
Previous offset producing erroneous values inconsistent with master channel's levels.
Updated and verified working on ATEM Production Studio 4K with firmware version 2.16