### PR TITLE
Fix error on camera data initialization

### DIFF
--- a/qatemcameracontrol.cpp
+++ b/qatemcameracontrol.cpp
@@ -45,7 +45,11 @@ void QAtemCameraControl::onCCdP(const QByteArray& payload)
 
     if(input >= m_cameras.count())
     {
-        m_cameras.append(new QAtem::Camera(input));
+        int index;
+        for (index = m_cameras.count(); index < input; index++)
+        {
+            m_cameras.append(new QAtem::Camera(index));
+        }
     }
 
     QAtem::Camera *camera = m_cameras[input - 1];


### PR DESCRIPTION
It seems like CCdP packets do not always come in the correct order (ascending inputs) or some inputs might be skipped.

This leads to an "index out of range" exception at [line 51](https://github.com/petersimonsson/libqatemcontrol/blob/3bdf646/qatemcameracontrol.cpp#L51) (ATEM version is 6.9). 
The proposed change fixes this exception.