### PR TITLE
Fix isConnected()

### DIFF
--- a/qatemconnection.cpp
+++ b/qatemconnection.cpp
@@ -109,7 +109,7 @@ QAtemConnection::~QAtemConnection()
 
 bool QAtemConnection::isConnected() const
 {
-    return m_socket && m_socket->isOpen() && m_isInitialized;
+    return m_socket && m_socket->isValid() && m_isInitialized;
 }
 
 void QAtemConnection::connectToSwitcher(const QHostAddress &address, int connectionTimeout)


### PR DESCRIPTION
Not entirely sure about this one:

In my tests `isOpen()` is always `false` although the connection is active. This seems reasonable, because there is no real connection like in TCP. 
Therefore `isValid()` might be a better option here?

I could not find a good documentation for `isOpen()` and `isValid()` with UDP sockets.