### PR TITLE
DSK: new fields "InTransition" and "InAutoTransition"

### DIFF
--- a/qatemdownstreamkey.cpp
+++ b/qatemdownstreamkey.cpp
@@ -266,11 +266,32 @@ void QAtemDownstreamKey::onDskS(const QByteArray& payload)
 
     if(index == m_id)
     {
-        m_onAir = (quint8)payload.at(7);
+        bool temp_onAir = m_onAir;
+        bool temp_inTransition = m_inTransition;
+        bool temp_inAutoTransition = m_inAutoTransition;
+        quint8 temp_frameCount = m_frameCount;
+
+        m_onAir = (quint8)payload.at(7) == 1;
+        m_inTransition = (quint8)payload.at(8) == 1;
+        m_inAutoTransition = (quint8)payload.at(9) == 1;
         m_frameCount = (quint8)payload.at(10);
 
-        emit onAirChanged(m_id, m_onAir);
-        emit frameCountChanged(m_id, m_frameCount);
+        if (m_onAir != temp_onAir)
+        {
+            emit onAirChanged(m_id, m_onAir);
+        }
+        if (m_inTransition != temp_inTransition)
+        {
+            emit inTransitionChanged(m_id, m_inTransition);
+        }
+        if (m_inAutoTransition != temp_inAutoTransition)
+        {
+            emit inAutoTransitionChanged(m_id, m_inAutoTransition);
+        }
+        if (m_frameCount != temp_frameCount)
+        {
+            emit frameCountChanged(m_id, m_frameCount);
+        }
     }
 }
 

--- a/qatemdownstreamkey.h
+++ b/qatemdownstreamkey.h
@@ -43,6 +43,8 @@ public:
     ~QAtemDownstreamKey();
 
     bool onAir() const { return m_onAir; }
+    bool inTransition() const { return m_inTransition; }
+    bool inAutoTransition() const { return m_inAutoTransition; }
     bool tie() const { return m_tie; }
     quint8 frameRate() const { return m_frameRate; }
     quint8 frameCount() const { return m_frameCount; }
@@ -82,6 +84,8 @@ private:
     quint8 m_id;
 
     bool m_onAir;
+    bool m_inTransition;
+    bool m_inAutoTransition;
     bool m_tie;
     quint8 m_frameRate;
     quint8 m_frameCount;
@@ -101,6 +105,8 @@ private:
 
 signals:
     void onAirChanged(quint8 keyer, bool state);
+    void inTransitionChanged(quint8 keyer, bool state);
+    void inAutoTransitionChanged(quint8 keyer, bool state);
     void tieChanged(quint8 keyer, bool state);
     void frameCountChanged(quint8 keyer, quint8 count);
     void frameRateChanged(quint8 keyer, quint8 frames);


### PR DESCRIPTION
- Added new fields for "DskS" command: "inTransition" and "inAutoTransition" (see http://skaarhoj.com/fileadmin/BMDPROTOCOL.html).
- Signals are only triggered, if the corresponding field changed.